### PR TITLE
Add className example

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Car = React.createClass
     <Vehicle doors={4} locked={isLocked()}  data-colour="red" on>
       <Parts.FrontSeat />
       <Parts.BackSeat />
-      <p>Which seat can I take? {@props?.seat or 'none'}</p>
+      <p className="kickin">Which seat can I take? {@props?.seat or 'none'}</p>
     </Vehicle>
 ```
 
@@ -32,7 +32,7 @@ Car = React.createClass
     Vehicle({"doors": (4), "locked": (isLocked()), "data-colour": "red", "on": true},
       Parts.FrontSeat(null),
       Parts.BackSeat(null),
-      React.DOM.p(null, "Which seat can I take? ", (@props?.seat or 'none'))
+      React.DOM.p({className: "kickin"}, "Which seat can I take? ", (@props?.seat or 'none'))
     )
 ```
 


### PR DESCRIPTION
As with JSX, it’s tempting for (especially) newbs to write <foo class="bar"> (because that’s what they would do in HTML), when the JavaScript version is actually `className`.
