### PR TITLE
Fix empty string being coerced to true

### DIFF
--- a/src/parser.coffee
+++ b/src/parser.coffee
@@ -167,13 +167,13 @@ module.exports = class Parser
       spreadAttr, whitespace ] = match
 
     if attrName
-      if doubleQuotedVal # "value"
+      if doubleQuotedVal? # "value"
         @addLeafNodeToActiveBranch parseTreeBranchNode($.CJSX_ATTR_PAIR, null, [
           parseTreeLeafNode($.CJSX_ATTR_KEY, "\"#{attrName}\"")
           parseTreeLeafNode($.CJSX_ATTR_VAL, "\"#{doubleQuotedVal}\"")
         ])
         return input.length
-      else if singleQuotedVal # 'value'
+      else if singleQuotedVal? # 'value'
         @addLeafNodeToActiveBranch parseTreeBranchNode($.CJSX_ATTR_PAIR, null, [
           parseTreeLeafNode($.CJSX_ATTR_KEY, "\"#{attrName}\"")
           parseTreeLeafNode($.CJSX_ATTR_VAL, "'#{singleQuotedVal}'")
@@ -201,7 +201,7 @@ module.exports = class Parser
       # on next iteration of parse loop, '{' will trigger CJSX_ESC state and be
       # parsed as CJSX_ESC (which has similar properties), to be transformed later
       return input.indexOf('{')
-    else if whitespace
+    else if whitespace?
       @addLeafNodeToActiveBranch parseTreeLeafNode($.CJSX_WHITESPACE, whitespace)
       return input.length
     else

--- a/test/output-testcases.txt
+++ b/test/output-testcases.txt
@@ -573,4 +573,12 @@ Component(Object.assign({}, x,
 )
 ##end
 
-
+##desc
+Empty strings are not converted to true 
+##input
+<Component val='' />
+<Component val="" />
+##expected
+Component({"val": ''})
+Component({"val": ""})
+##end


### PR DESCRIPTION
The normal JSX compiler does not coerce empty strings for component props to `true`

``` html
<Component prop='' />
```

should output:

``` js
Component({prop: ''})
```

but coffee-react currently outputs

``` coffee
Component({"prop": true})
```

This fixes that behavior.
