### PR TITLE
Remove trailing space in component attributes

### DIFF
--- a/src/serialiser.coffee
+++ b/src/serialiser.coffee
@@ -139,7 +139,7 @@ nodeSerialisers =
       prefix = @domObject+'.'
     else
       prefix = ''
-    "#{@reactObject}.createElement(#{prefix}#{node.value}, #{serialisedChildren.join(', ')})"
+    "#{@reactObject}.createElement(#{prefix}#{node.value}, #{serialisedChildren.join(',')})"
 
   CJSX_ESC: (node) ->
     childrenSerialised = node.children


### PR DESCRIPTION
When component attributes are serialized, we no longer join with a comma
and trailing space. This ensures that files that are Coffeelint-ed don't
throw errors about trailing whitespace.

This doesn't appear to damage any formatting for the rest of the serialization, and the tests pass just fine. You'll know better than me whether or not this will have impacts outside of the use case I describe.
