### PR TITLE
Render all strings with single quotes

### DIFF
--- a/src/parser.coffee
+++ b/src/parser.coffee
@@ -169,30 +169,30 @@ module.exports = class Parser
     if attrName
       if doubleQuotedVal? # "value"
         @addLeafNodeToActiveBranch ParseTreeBranchNode($.CJSX_ATTR_PAIR, null, [
-          ParseTreeLeafNode($.CJSX_ATTR_KEY, "\"#{attrName}\"")
-          ParseTreeLeafNode($.CJSX_ATTR_VAL, "\"#{doubleQuotedVal}\"")
+          ParseTreeLeafNode($.CJSX_ATTR_KEY, "'#{attrName}'")
+          ParseTreeLeafNode($.CJSX_ATTR_VAL, "'#{doubleQuotedVal}'")
         ])
         return input.length
       else if singleQuotedVal? # 'value'
         @addLeafNodeToActiveBranch ParseTreeBranchNode($.CJSX_ATTR_PAIR, null, [
-          ParseTreeLeafNode($.CJSX_ATTR_KEY, "\"#{attrName}\"")
+          ParseTreeLeafNode($.CJSX_ATTR_KEY, "'#{attrName}'")
           ParseTreeLeafNode($.CJSX_ATTR_VAL, "'#{singleQuotedVal}'")
         ])
         return input.length
       else if cjsxEscVal # {value}
         @pushActiveBranchNode ParseTreeBranchNode $.CJSX_ATTR_PAIR
-        @addLeafNodeToActiveBranch ParseTreeLeafNode($.CJSX_ATTR_KEY, "\"#{attrName}\"")
+        @addLeafNodeToActiveBranch ParseTreeLeafNode($.CJSX_ATTR_KEY, "'#{attrName}'")
         # on next iteration of parse loop, '{' will trigger CJSX_ESC state
         return input.indexOf('{') # consume up to start of cjsx escape
       else if bareVal # value
         @addLeafNodeToActiveBranch ParseTreeBranchNode($.CJSX_ATTR_PAIR, null, [
-          ParseTreeLeafNode($.CJSX_ATTR_KEY, "\"#{attrName}\"")
+          ParseTreeLeafNode($.CJSX_ATTR_KEY, "'#{attrName}'")
           ParseTreeLeafNode($.CJSX_ATTR_VAL, bareVal)
         ])
         return input.length
       else # valueless attr
         @addLeafNodeToActiveBranch ParseTreeBranchNode($.CJSX_ATTR_PAIR, null, [
-          ParseTreeLeafNode($.CJSX_ATTR_KEY, "\"#{attrName}\"")
+          ParseTreeLeafNode($.CJSX_ATTR_KEY, "'#{attrName}'")
           ParseTreeLeafNode($.CJSX_ATTR_VAL, 'true')
         ])
         return input.length

--- a/src/serialiser.coffee
+++ b/src/serialiser.coffee
@@ -205,7 +205,7 @@ nodeSerialisers =
       else
         # decode html entities to chars
         # escape string special chars
-        '"'+stringEscape(entityDecode(text))+'"'
+        '\''+stringEscape(entityDecode(text), singleQuotes: true)+'\''
 
   CJSX_ATTR_KEY: genericLeafSerialiser
   CJSX_ATTR_VAL: genericLeafSerialiser

--- a/src/stringescape.js
+++ b/src/stringescape.js
@@ -4,32 +4,44 @@ var hex = '0123456789abcdef'.split('');
 module.exports  =  function stringEncode(input, opts) {
   opts = opts || {};
   var escaped = "";
-  
+
   for (var i = 0; i < input.length; i++) {
-    escaped = escaped + encodeChar(input.charAt(i), opts.preserveNewlines);
+    translation = encodeChar(input.charAt(i), opts);
+    escaped = escaped + translation
   }
   
   return escaped;
 }
 
-function encodeChar(inputChar, preserveNewlines) {
+function encodeChar(inputChar, opts) {
   var character = inputChar.charAt(0);
   var characterCode = inputChar.charCodeAt(0);
 
   switch(character) {
     case '\n':
-      if (!preserveNewlines) return "\\n";
-      else return character;
+      if (opts.singleQuotes) return character;
+      if (!opts.preserveNewlines) return "\\n";
+      return character;
     case '\r':
-      if (!preserveNewlines) return "\\r";
-      else return character;
+      if (opts.singleQuotes) return character;
+      if (!opts.preserveNewlines) return "\\r";
+      return character;
     case '\'': return "\\'";
-    case '"': return "\\\"";
-    case '\&': return "\\&";
+    case '"':
+      if (opts.singleQuotes) return character;
+      return "\\\"";
+    case '\&':
+      return "\\&";
     case '\\': return "\\\\";
-    case '\t': return "\\t";
-    case '\b': return "\\b";
-    case '\f': return "\\f";
+    case '\t':
+      if (opts.singleQuotes) return character;
+      return "\\t";
+    case '\b':
+      if (opts.singleQuotes) return character;
+      return "\\b";
+    case '\f':
+      if (opts.singleQuotes) return character;
+      return "\\f";
     case '/': return "\\x2F";
     case '<': return "\\x3C";
     case '>': return "\\x3E";

--- a/test/output-testcases.txt
+++ b/test/output-testcases.txt
@@ -31,7 +31,7 @@ ambigious tag
 ##input
 x = a <b > c </b>
 ##expected
-x = a React.createElement(React.DOM.b, null, " c ")
+x = a React.createElement(React.DOM.b, null, ' c ')
 ##end
 
 ##desc
@@ -39,7 +39,7 @@ numeric bare attribute
 ##input
 x = <table width=100 />
 ##expected
-x = React.createElement(React.DOM.table, {"width": 100})
+x = React.createElement(React.DOM.table, {'width': 100})
 ##end
 
 ##desc
@@ -47,7 +47,7 @@ numeric escaped coffeescript attribute
 ##input
 x = <table width={100} />
 ##expected
-x = React.createElement(React.DOM.table, {"width": (100)})
+x = React.createElement(React.DOM.table, {'width': (100)})
 ##end
 
 ##desc
@@ -55,7 +55,7 @@ string attribute
 ##input
 x = <table width="100" />
 ##expected
-x = React.createElement(React.DOM.table, {"width": "100"})
+x = React.createElement(React.DOM.table, {'width': '100'})
 ##end
 
 ##desc
@@ -63,7 +63,7 @@ escaped coffeescript attribute
 ##input
 <Person name={ if test() then 'yes' else 'no'} />
 ##expected
-React.createElement(Person, {"name": ( if test() then 'yes' else 'no')})
+React.createElement(Person, {'name': ( if test() then 'yes' else 'no')})
 ##end
 
 ##desc
@@ -76,7 +76,7 @@ escaped coffeescript attribute over multiple lines
     'no'
 } />
 ##expected
-React.createElement(Person, {"name": (
+React.createElement(Person, {'name': (
   if test()
     'yes'
   else
@@ -104,7 +104,7 @@ multiple line escaped coffeescript with nested cjsx
 
 </Person>
 ##expected
-React.createElement(Person, {"name": (
+React.createElement(Person, {'name': (
   if test()
     'yes'
   else
@@ -115,7 +115,7 @@ React.createElement(Person, {"name": (
   for n in a
     React.createElement(React.DOM.div, null, """ a
       asf
-""", React.createElement(React.DOM.li, {"xy": ("as")}, ( n+1 ), React.createElement(React.DOM.a, null), " ", React.createElement(React.DOM.a, null), " ")
+""", React.createElement(React.DOM.li, {'xy': ("as")}, ( n+1 ), React.createElement(React.DOM.a, null), ' ', React.createElement(React.DOM.a, null), ' ')
     )
 )
 
@@ -131,7 +131,7 @@ nested cjsx within an attribute, with object attr value
 </Company>
 ##expected
 React.createElement(Company, null,
-  React.createElement(Person, {"name": (React.createElement(NameComponent, {"attr3": ( {'a': {}, b: '{'} )}))})
+  React.createElement(Person, {'name': (React.createElement(NameComponent, {'attr3': ( {'a': {}, b: '{'} )}))})
 )
 ##end
 
@@ -140,7 +140,7 @@ complex nesting
 ##input
 <div code={someFunc({a:{b:{}, C:'}{}{'}})} />
 ##expected
-React.createElement(React.DOM.div, {"code": (someFunc({a:{b:{}, C:'}{}{'}}))})
+React.createElement(React.DOM.div, {'code': (someFunc({a:{b:{}, C:'}{}{'}}))})
 ##end
 
 ##desc
@@ -156,9 +156,9 @@ multiline tag with nested cjsx within an attribute
 </Person>
 ##expected
 React.createElement(Person, { \
-  "name": (
+  'name': (
     name = formatName(user.name)
-    React.createElement(NameComponent, {"name": (name.toUppercase())})
+    React.createElement(NameComponent, {'name': (name.toUppercase())})
   )
 }, """
   blah blah blah
@@ -187,8 +187,8 @@ multiline tag attributes with escaped coffeescript
 <Person name={if isActive() then 'active' else 'inactive'}
 someattr='on new line' />
 ##expected
-React.createElement(Person, {"name": (if isActive() then 'active' else 'inactive'),  \
-"someattr": 'on new line'})
+React.createElement(Person, {'name': (if isActive() then 'active' else 'inactive'),  \
+'someattr': 'on new line'})
 ##end
 
 ##desc
@@ -208,7 +208,7 @@ HelloWorld = React.createClass({
   render: () ->
     return (
       React.createElement(React.DOM.p, null, """
-        Hello, """, React.createElement(React.DOM.input, {"type": "text", "placeholder": "Your name here"}), """!
+        Hello, """, React.createElement(React.DOM.input, {'type': 'text', 'placeholder': 'Your name here'}), """!
         It is """, (this.props.date.toTimeString())
       )
     );
@@ -233,15 +233,15 @@ React.createClass
 ##expected
 setInterval(() ->
   React.renderComponent(
-    React.createElement(HelloWorld, {"date": "{new Date()}"}),
+    React.createElement(HelloWorld, {'date': '{new Date()}'}),
     document.getElementById('example')
   );
 , 500);
 
 React.createClass
   render: ->
-    return React.createElement(Nav, {"color": "blue"},
-      (React.createElement(Profile, null, "click", (Math.random())) for i in [start...finish])
+    return React.createElement(Nav, {'color': 'blue'},
+      (React.createElement(Profile, null, 'click', (Math.random())) for i in [start...finish])
     )
 ##end
 
@@ -254,8 +254,8 @@ active={ if isActive() then 'active' else 'inactive' } data-attr='works' checked
 />
 ##expected
 
-React.createElement(Person, {"eyes": 2, "friends": (getFriends()), "popular": "yes",  \
-"active": ( if isActive() then 'active' else 'inactive' ), "data-attr": 'works', "checked": true, "check": me_out
+React.createElement(Person, {'eyes': 2, 'friends': (getFriends()), 'popular': 'yes',  \
+'active': ( if isActive() then 'active' else 'inactive' ), 'data-attr': 'works', 'checked': true, 'check': me_out
 })
 ##end
 
@@ -281,7 +281,7 @@ multiline elements
   </div>
   </div>
 ##expected
-  React.createElement(React.DOM.div, {"something": (
+  React.createElement(React.DOM.div, {'something': (
     do ->
       test = /432/gm # this is a regex
       6 /432/gm # this is division
@@ -290,8 +290,8 @@ multiline elements
   React.createElement(React.DOM.div, null,
   React.createElement(React.DOM.div, null,
   React.createElement(React.DOM.div, null,
-    React.createElement(React.DOM.article, {"name": ( new Date() ), "number": 203,  \
-     "range": (getRange())
+    React.createElement(React.DOM.article, {'name': ( new Date() ), 'number': 203,  \
+     'range': (getRange())
     }
     )
   )
@@ -314,7 +314,7 @@ pragma with alternate dom implementation
 
 awesome.createElement(awesome.fun.div, null, """ a
   asf
-""", awesome.createElement(awesome.fun.li, {"xy": ("as")}, ( n+1 ), awesome.createElement(awesome.fun.a, null), " ", awesome.createElement(awesome.fun.a, null), " ")
+""", awesome.createElement(awesome.fun.li, {'xy': ("as")}, ( n+1 ), awesome.createElement(awesome.fun.a, null), ' ', awesome.createElement(awesome.fun.a, null), ' ')
 )
 ##end
 
@@ -325,7 +325,7 @@ pragma is case insensitive
 <div> a </div>
 ##expected
 
-React.createElement(cool.div, null, " a ")
+React.createElement(cool.div, null, ' a ')
 ##end
 
 ##desc
@@ -462,7 +462,7 @@ escaped js within cjsx is ignored by parser
 ##input
 <Person> `i am not js` </Person>
 ##expected
-React.createElement(Person, null, " `i am not js` ")
+React.createElement(Person, null, ' `i am not js` ')
 ##end
 
 ##desc
@@ -482,7 +482,7 @@ string within cjsx is ignored by parser and escaped
 ##input
 <Person> "i am not a string" 'nor am i' </Person>
 ##expected
-React.createElement(Person, null, " \"i am not a string\" \'nor am i\' ")
+React.createElement(Person, null, ' "i am not a string" \'nor am i\' ')
 ##end
 
 ##desc
@@ -490,7 +490,7 @@ special chars within cjsx are ignored by parser and escaped
 ##input
 <Person> a,/';][' a\''@$%^&˚¬∑˜˚∆å∂¬˚*()*&^%$>><<<< '"''"'''\'\'m' i </Person>
 ##expected
-React.createElement(Person, null, " a,\x2F\';][\' a\\\'\'@$%^\&\u02da\u00ac\u2211\u02dc\u02da\u2206\u00e5\u2202\u00ac\u02da*()*\&^%$\x3E\x3E\x3C\x3C\x3C\x3C \'\"\'\'\"\'\'\'\\\'\\\'m\' i ")
+React.createElement(Person, null, ' a,\x2F\';][\' a\\\'\'@$%^\&\u02da\u00ac\u2211\u02dc\u02da\u2206\u00e5\u2202\u00ac\u02da*()*\&^%$\x3E\x3E\x3C\x3C\x3C\x3C \'"\'\'"\'\'\'\\\'\\\'m\' i ')
 ##end
 
 ##desc
@@ -498,7 +498,7 @@ html entities (name, decimal, hex) within cjsx decoded
 ##input
 <Person>  &&&&euro;  &#8364; &#x20AC;;; </Person>
 ##expected
-React.createElement(Person, null, "  \&\&\&\u20ac  \u20ac \u20ac;; ")
+React.createElement(Person, null, '  \&\&\&\u20ac  \u20ac \u20ac;; ')
 ##end
 
 ##desc
@@ -506,7 +506,7 @@ tag with {{}}
 ##input
 <Person name={{value: item, key, item}} />
 ##expected
-React.createElement(Person, {"name": ({value: item, key, item})})
+React.createElement(Person, {'name': ({value: item, key, item})})
 ##end
 
 ##desc
@@ -530,7 +530,7 @@ self closing tag with spread attribute
 ##input
 <Component a={b} {... x } b="c" />
 ##expected
-React.createElement(Component, Object.assign({"a": (b)},  x , {"b": "c"}))
+React.createElement(Component, Object.assign({'a': (b)},  x , {'b': 'c'}))
 ##end
 
 ##desc
@@ -538,7 +538,7 @@ complex spread attribute
 ##input
 <Component {...x} a={b} {... x } b="c" {...$my_xtraCoolVar123 } />
 ##expected
-React.createElement(Component, Object.assign({}, x, {"a": (b)},  x , {"b": "c"}, $my_xtraCoolVar123 ))
+React.createElement(Component, Object.assign({}, x, {'a': (b)},  x , {'b': 'c'}, $my_xtraCoolVar123 ))
 ##end
 
 ##desc
@@ -550,7 +550,7 @@ multiline spread attribute
 </Component>
 ##expected
 React.createElement(Component, Object.assign({},
-  x , {"a": (b)},  x , {"b": "c"}, z )
+  x , {'a': (b)},  x , {'b': 'c'}, z )
 )
 ##end
 
@@ -564,8 +564,8 @@ complex multiline spread attribute
 </Component>
 ##expected
 React.createElement(Component, Object.assign({},
-  y, {"a": (b)},  x , {"b": "c"}, z ),
-  React.createElement(React.DOM.div, {"code": (someFunc({a:{b:{}, C:'}'}}))})
+  y, {'a': (b)},  x , {'b': 'c'}, z ),
+  React.createElement(React.DOM.div, {'code': (someFunc({a:{b:{}, C:'}'}}))})
 )
 ##end
 
@@ -575,8 +575,8 @@ Empty strings are not converted to true
 <Component val='' />
 <Component val="" />
 ##expected
-React.createElement(Component, {"val": ''})
-React.createElement(Component, {"val": ""})
+React.createElement(Component, {'val': ''})
+React.createElement(Component, {'val': ''})
 ##end
 
 ##desc


### PR DESCRIPTION
When I was working on https://github.com/clutchski/coffeelint/pull/346, I noticed that there were a lot of unneeded double quotes in the output. Since they have a special meaning in coffee script this could also mean unintended string interpolation.

I probably missed some edge cases, so please take a good look before merging!