### PR TITLE
Comments in multiline JSX tags are parsed wrongly

### DIFF
--- a/test/output-testcases.txt
+++ b/test/output-testcases.txt
@@ -631,3 +631,18 @@ React.createElement(@component, null,
   React.createElement(component, null)
 )
 ##end
+
+##desc
+Support comments in the middle of a multiline function call args list.
+
+Coffeescript drops these comments so I’m assuming we should to.
+##input
+<foo>
+  <bar />
+  # <baz /> leaving baz unimplemented
+</foo>
+##expected
+React.createElement(foo, null,
+  React.createElement(bar, null)
+)
+##end


### PR DESCRIPTION
In the code

    <foo>
      <bar />
      # <baz /> leaving baz unimplemented
    </foo>

I’d expect the comment to be ignored - instead, it seems to be parsed and placed into the function call, as follows:

    React.createElement(foo, null,
      React.createElement(bar, null), """
      # """, React.createElement(baz, null), """ leaving baz unimplemented
    """)

I’m assuming this is a bug, and I attached a failing test case.
