### PR TITLE
Fix literate CoffeeScript/CJSX with single apostrophes in Markdown

### DIFF
--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -136,3 +136,14 @@ exports.nameWhitespaceCharacter = (string) ->
     when '\r' then 'carriage return'
     when '\t' then 'tab'
     else string
+
+exports.invertLiterate = (code) ->
+  maybe_code = true
+  lines = for line in code.split('\n')
+    if maybe_code and /^([ ]{4}|[ ]{0,3}\t)/.test line
+      line
+    else if maybe_code = /^\s*$/.test line
+      line
+    else
+      '# ' + line
+  lines.join '\n'

--- a/src/parser.coffee
+++ b/src/parser.coffee
@@ -1,6 +1,6 @@
 
 # Import the helpers we need.
-{count, starts, compact, last, repeat, throwSyntaxError} = require './helpers'
+{count, starts, compact, last, repeat, throwSyntaxError, invertLiterate} = require './helpers'
 
 $ = require './symbols'
 
@@ -305,6 +305,7 @@ module.exports = class Parser
   clean: (code) ->
     code = code.slice(1) if code.charCodeAt(0) is BOM
     code = code.replace(/\r/g, '') # strip carriage return chars
+    code = invertLiterate code if @opts?.literate
     code
 
   # Returns the line and column number from an offset into the current chunk.

--- a/test/output-testcases.txt
+++ b/test/output-testcases.txt
@@ -742,3 +742,15 @@ custom element
 ##expected
 React.createElement("paper-button", {"className": "button"}, (text))
 ##end
+
+##desc
+literate cjsx
+##input
+Don't get caught out by apostrophes.
+
+    console.log <A />
+##expected
+# Don't get caught out by apostrophes.
+
+    console.log React.createElement(A, null)
+##end

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -18,7 +18,8 @@ else
 
 tryTransform = (input, desc) ->
   try
-    transformed = transform input
+    options = literate: desc.match /literate/
+    transformed = transform input, options
   catch e
     e.message = """
     transform error in testcase: #{desc}
@@ -32,7 +33,8 @@ tryTransform = (input, desc) ->
 
 tryCompile = (input, desc) ->
   try
-    compiled = coffeeCompile input
+    options = literate: desc.match /literate/
+    compiled = coffeeCompile input, options
   catch e
     e.message = """
     compile error in testcase: #{desc}

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -16,9 +16,8 @@ if process.env.DEBUG
 else
   transform = require '../'
 
-tryTransform = (input, desc) ->
+tryTransform = (input, options, desc) ->
   try
-    options = literate: desc.match /literate/
     transformed = transform input, options
   catch e
     e.message = """
@@ -31,9 +30,8 @@ tryTransform = (input, desc) ->
 
   transformed
 
-tryCompile = (input, desc) ->
+tryCompile = (input, options, desc) ->
   try
-    options = literate: desc.match /literate/
     compiled = coffeeCompile input, options
   catch e
     e.message = """
@@ -55,9 +53,11 @@ testTypes =
   'output':
     params: ['desc','input','expected']
     runner: (testcase) ->
-      transformed = tryTransform testcase.input, testcase.desc
+      options = literate: testcase.desc.match /literate/
 
-      compiled = tryCompile transformed, testcase.desc
+      transformed = tryTransform testcase.input, options, testcase.desc
+
+      compiled = tryCompile transformed, options, testcase.desc
 
       # simple assertion of string equality of expected output and actual output
       pass = transformed is testcase.expected


### PR DESCRIPTION
Takes the [invertLiterate method from CoffeeScript's helpers](https://github.com/jashkenas/coffeescript/blob/bd17cc9b3c424c0122bc15cfac6006cce1a89bbb/src/helpers.coffee#L73-L82) and uses it to pre-filter literate files. This is necessary for literate files that contain single apostrophes in the markdown (otherwise it fails on [this line](https://github.com/jsdf/coffee-react-transform/blob/68a3b716798ca2380d5cf4be2da6f8de4c82f702/src/parser.coffee#L93) - see jsdf/coffee-react#21 for a minimal testcase).

I've added a test, but I had to pass the literate option which I've inferred by matching the test description - let me know if there's a better way.