### PR TITLE
Replace React.__spread with Object.assign

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ extraProps = color: 'red', speed: 'fast'
 which is transformed to:
 ```coffee
 extraProps = color: 'red', speed: 'fast'
-React.createElement("div", React.__spread({"color": "blue"},  extraProps)
+React.createElement("div", Object.assign({"color": "blue"},  extraProps)
 ```
 
 ### Tests

--- a/src/serialiser.coffee
+++ b/src/serialiser.coffee
@@ -102,7 +102,7 @@ class Serialiser
 
     joinedAssigns = joinList(assignsWithWhitespace)
 
-    "React.__spread(#{joinList(assignsWithWhitespace)})"
+    "Object.assign(#{joinList(assignsWithWhitespace)})"
 
   serialiseAttributePairs: (children) ->
     # whitespace (particularly newlines) must be maintained

--- a/test/output-testcases.txt
+++ b/test/output-testcases.txt
@@ -584,7 +584,7 @@ self closing tag with spread attribute
 ##input
 <Component a={b} {... x } b="c" />
 ##expected
-React.createElement(Component, React.__spread({"a": (b)},  x , {"b": "c"}))
+React.createElement(Component, Object.assign({"a": (b)},  x , {"b": "c"}))
 ##end
 
 ##desc
@@ -592,7 +592,7 @@ complex spread attribute
 ##input
 <Component {...x} a={b} {... x } b="c" {...$my_xtraCoolVar123 } />
 ##expected
-React.createElement(Component, React.__spread({},  x, {"a": (b)},  x , {"b": "c"}, $my_xtraCoolVar123  ))
+React.createElement(Component, Object.assign({},  x, {"a": (b)},  x , {"b": "c"}, $my_xtraCoolVar123  ))
 ##end
 
 ##desc
@@ -602,7 +602,7 @@ multiline spread attribute
   x } a={b} {... x } b="c" {...z }>
 </Component>
 ##expected
-React.createElement(Component, React.__spread({},  
+React.createElement(Component, Object.assign({},  
   x , {"a": (b)},  x , {"b": "c"}, z )
 )
 ##end
@@ -618,7 +618,7 @@ multiline tag with spread attribute
 >
 </Component>
 ##expected
-React.createElement(Component, React.__spread({ \
+React.createElement(Component, Object.assign({ \
   "z": "1"
   }, x, { \
   "a": (b),  \
@@ -638,7 +638,7 @@ multiline tag with spread attribute first
 >
 </Component>
 ##expected
-React.createElement(Component, React.__spread({}, \
+React.createElement(Component, Object.assign({}, \
   
   x, { \
   "z": "1",  \
@@ -657,7 +657,7 @@ complex multiline spread attribute
   <div code={someFunc({a:{b:{}, C:'}'}})} />
 </Component>
 ##expected
-React.createElement(Component, React.__spread({}, \
+React.createElement(Component, Object.assign({}, \
   
   y, {"a": (b)},  x , {"b": "c"}, z ),
   React.createElement("div", {"code": (someFunc({a:{b:{}, C:'}'}}))})
@@ -669,7 +669,7 @@ self closing spread attribute on single line
 ##input
 <Component a="b" c="d" {...@props} />
 ##expected
-React.createElement(Component, React.__spread({"a": "b", "c": "d"}, @props ))
+React.createElement(Component, Object.assign({"a": "b", "c": "d"}, @props ))
 ##end
 
 ##desc
@@ -681,7 +681,7 @@ self closing spread attribute on new line
   {...@props}
 />
 ##expected
-React.createElement(Component, React.__spread({ \
+React.createElement(Component, Object.assign({ \
   "a": "b",  \
   "c": "d"
   }, @props
@@ -696,7 +696,7 @@ self closing spread attribute on same line
   c="d"
   {...@props} />
 ##expected
-React.createElement(Component, React.__spread({ \
+React.createElement(Component, Object.assign({ \
   "a": "b",  \
   "c": "d"
   }, @props ))
@@ -712,7 +712,7 @@ self closing spread attribute on next line
 
 />
 ##expected
-React.createElement(Component, React.__spread({ \
+React.createElement(Component, Object.assign({ \
   "a": "b",  \
   "c": "d"
   }, @props


### PR DESCRIPTION
Addresses https://github.com/jsdf/coffee-react-transform/issues/70 React 0.15.1 works, but throws warnings when using `__spread`.

@jsdf you mentioned still supporting `__spread`, but it will be removed from React soon. Can we not just replace it with `Object.assign`?